### PR TITLE
Update manifest to version 2

### DIFF
--- a/js/adapter.js
+++ b/js/adapter.js
@@ -1,0 +1,1 @@
+OAuth2.parseAccessCode(window.location.href);

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,7 @@
 {
-	"background_page" : "background.html",
+    "background": {
+	"page" : "background.html"
+    },
     "browser_action": {
         "default_icon": "img/icon_128x128.png",
         "default_title": "GitHub Repositories",
@@ -26,5 +28,6 @@
     	"https://github.com/*",
     	"https://api.github.com/*"
     ],     
-    "version": "2.1.5"
+    "version": "2.1.5",
+    "manifest_version": 2
 }


### PR DESCRIPTION
This is now required by chrome in order to be able to load the unpacked extension as a developer. Apparently manifest version 1 extensions are currently also being phased out of the app store - http://developer.chrome.com/extensions/manifestVersion.html
